### PR TITLE
Fix typo in git submodule upload dwm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
     cd dwm-patches
     git submodule init dwm
-    git submodule upload dwm
+    git submodule update dwm
 
 ## activate all patches, including the personal configuration
 


### PR DESCRIPTION
Trying to execute the command in the readme (`git submodule upload dwm`) give me an syntax error. I tried with `update` instead of `upload` and everything went correct.
